### PR TITLE
🐛 Fix deployment errors to AWS Lambda

### DIFF
--- a/cinema-catalog-service/package.json
+++ b/cinema-catalog-service/package.json
@@ -65,7 +65,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "build:copy": "cpx \"src/**/*.yaml\" dist/src",
+    "build:copy": "cpx ./src/definition/* ./dist/definition",
     "start": "DEBUG=app:* node dist/src/index.js",
     "build:live": "npm run clean && npm run lint && tsc -p tsconfig.json && npm run build:copy && cp package* ./dist && npm install --production --prefix ./dist",
     "build:dev": "nodemon --exec ts-node -- ./src/index.ts",

--- a/cinema-catalog-service/serverless.yml
+++ b/cinema-catalog-service/serverless.yml
@@ -1,9 +1,10 @@
+---
 service: cinema-catalog-service
 
 provider:
   name: aws
   runtime: nodejs8.10
-  stage: ${opt:stage, 'dev'}
+  stage: ${opt:stage, "dev"}
   region: ap-northeast-1
   environment:
     DATABASE_HOST: ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessAuroraEndpointAddress}
@@ -36,8 +37,8 @@ package:
     - "!package.json"
 
 functions:
-  http:
-    handler: dist/src/lambda.http
+  app:
+    handler: dist/lambda.http
     events:
       - http:
           path: /
@@ -55,7 +56,7 @@ functions:
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessPrivateSubnetB}
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessPrivateSubnetC}
   db-migrate-up:
-    handler: dist/src/lib/db-migrate.migrate
+    handler: dist/lib/db-migrate.migrate
     vpc:
       securityGroupIds:
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessDefaultSecurityGroup}

--- a/movies-service/package.json
+++ b/movies-service/package.json
@@ -66,7 +66,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "build:copy": "cpx \"src/**/*.yaml\" dist/src",
+    "build:copy": "cpx ./src/definition/* ./dist/definition",
     "start": "DEBUG=app:* node dist/src/index.js",
     "build:live": "npm run clean && npm run lint && tsc -p tsconfig.json && npm run build:copy && cp package* ./dist && npm install --production --prefix ./dist",
     "build:dev": "nodemon --exec ts-node -- ./src/index.ts",

--- a/movies-service/serverless.yml
+++ b/movies-service/serverless.yml
@@ -1,9 +1,10 @@
+---
 service: movies-service
 
 provider:
   name: aws
   runtime: nodejs8.10
-  stage: ${opt:stage, 'dev'}
+  stage: ${opt:stage, "dev"}
   region: ap-northeast-1
   environment:
     DATABASE_HOST: ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessAuroraEndpointAddress}
@@ -36,8 +37,8 @@ package:
     - "!package.json"
 
 functions:
-  http:
-    handler: dist/src/lambda.http
+  app:
+    handler: dist/lambda.http
     events:
       - http:
           path: /
@@ -56,7 +57,7 @@ functions:
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessPrivateSubnetC}
 
   db-migrate-up:
-    handler: dist/src/lib/db-migrate.migrate
+    handler: dist/lib/db-migrate.migrate
     vpc:
       securityGroupIds:
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessDefaultSecurityGroup}

--- a/search-service/package.json
+++ b/search-service/package.json
@@ -65,7 +65,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "build:copy": "cpx \"src/**/*.yaml\" dist/src",
+    "build:copy": "cpx ./src/definition/* ./dist/definition",
     "start": "DEBUG=app:* node dist/src/index.js",
     "build:live": "npm run clean && npm run lint && tsc -p tsconfig.json && npm run build:copy && cp package* ./dist && npm install --production --prefix ./dist",
     "build:dev": "nodemon --exec ts-node -- ./src/index.ts",

--- a/search-service/serverless.yml
+++ b/search-service/serverless.yml
@@ -1,9 +1,10 @@
+---
 service: movies-service
 
 provider:
   name: aws
   runtime: nodejs8.10
-  stage: ${opt:stage, 'dev'}
+  stage: ${opt:stage, "dev"}
   region: ap-northeast-1
   environment:
     DATABASE_HOST: ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessAuroraEndpointAddress}
@@ -25,7 +26,7 @@ package:
 
 functions:
   hello-get:
-    handler: dist/src/lambda.http
+    handler: dist/lambda.http
     events:
       - http:
           path: /api/hello
@@ -44,7 +45,7 @@ functions:
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessPrivateSubnetC}
 
   goodbye-post:
-    handler: dist/src/lambda.http
+    handler: dist/lambda.http
     events:
       - http:
           path: /api/goodbye/{postId}
@@ -63,7 +64,7 @@ functions:
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessPrivateSubnetC}
 
   other:
-    handler: dist/src/lambda.http
+    handler: dist/lambda.http
     events:
       - http:
           path: /
@@ -82,7 +83,7 @@ functions:
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessPrivateSubnetC}
 
   db-migrate-up:
-    handler: dist/src/lib/db-migrate.migrate
+    handler: dist/lib/db-migrate.migrate
     vpc:
       securityGroupIds:
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessDefaultSecurityGroup}

--- a/shared-infra/serverless.yml
+++ b/shared-infra/serverless.yml
@@ -1,9 +1,10 @@
+---
 service: shared-infra
 
 provider:
   name: aws
   runtime: nodejs8.10
-  stage: ${opt:stage, 'dev'}
+  stage: ${opt:stage, "dev"}
   region: ap-northeast-1
   environment:
     AURORA_HOST: ${self:custom.AURORA.HOST}
@@ -95,7 +96,7 @@ resources:
         SubnetId:
           Ref: ServerlessPublicSubnetA
         RouteTableId:
-          Ref: DefaultPublicRouteTable    
+          Ref: DefaultPublicRouteTable
     # NatGateway
     ElasticIpLambda:
       Type: AWS::EC2::EIP
@@ -186,7 +187,7 @@ resources:
       Export:
         Name: ServerlessVPC
     ServerlessDefaultSecurityGroup:
-      Value: 
+      Value:
         Fn::GetAtt: ServerlessVPC.DefaultSecurityGroup
       Export:
         Name: ServerlessDefaultSecurityGroup

--- a/template-service/package.json
+++ b/template-service/package.json
@@ -65,7 +65,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "build:copy": "cpx \"src/**/*.yaml\" dist/src",
+    "build:copy": "cpx ./src/definition/* ./dist/definition",
     "start": "DEBUG=app:* node dist/src/index.js",
     "build:live": "npm run clean && npm run lint && tsc -p tsconfig.json && npm run build:copy && cp package* ./dist && npm install --production --prefix ./dist",
     "build:dev": "nodemon --exec ts-node -- ./src/index.ts",

--- a/template-service/serverless.yml
+++ b/template-service/serverless.yml
@@ -1,9 +1,10 @@
+---
 service: template-service
 
 provider:
   name: aws
   runtime: nodejs8.10
-  stage: ${opt:stage, 'dev'}
+  stage: ${opt:stage, "dev"}
   region: ap-northeast-1
   environment:
     DEBUG: app:*
@@ -19,8 +20,8 @@ package:
     - "!package.json"
 
 functions:
-  http:
-    handler: dist/src/lambda.http
+  app:
+    handler: dist/lambda.http
     events:
       - http:
           path: /
@@ -37,9 +38,9 @@ functions:
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessPrivateSubnetA}
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessPrivateSubnetB}
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessPrivateSubnetC}
-        
+
   db-migrate-up:
-    handler: dist/src/lib/db-migrate.migrate
+    handler: dist/lib/db-migrate.migrate
     vpc:
       securityGroupIds:
         - ${cf.${self:provider.region}:shared-infra-${opt:stage, self:provider.stage}.ServerlessDefaultSecurityGroup}


### PR DESCRIPTION
I encountered two errors when deploying to AWS Lambda.

1. Lambda can't find handler

```
Unable to import module 'dist/src/lambda': Error at
Function.Module._resolveFilename (module.js:547:15) at
Function.Module._load (module.js:474:25) at Module.require
(module.js:596:17) at require (internal/module.js:11:18)
```

2. Express can't find OpenAPI definition file

```
module initialization error: Error
```